### PR TITLE
some fixes ...

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -33,6 +33,8 @@ fi
 # Create the config file (overwriting the existing one)
 echo "Setting up the configuration file"
 echo "[Upload]" > /etc/systemd/journal-upload.conf
+# remove executable bit to quieten log spam on startup
+chmod -x /etc/systemd/journal-upload.conf
 echo "URL=$url" >> /etc/systemd/journal-upload.conf
 
 # Add the TLS certificate options

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -33,8 +33,6 @@ fi
 # Create the config file (overwriting the existing one)
 echo "Setting up the configuration file"
 echo "[Upload]" > /etc/systemd/journal-upload.conf
-# remove executable bit to quieten log spam on startup
-chmod -x /etc/systemd/journal-upload.conf
 echo "URL=$url" >> /etc/systemd/journal-upload.conf
 
 # Add the TLS certificate options

--- a/snap/hooks/connect-plug-config-logsync
+++ b/snap/hooks/connect-plug-config-logsync
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-snapctl restart ${SNAP_NAME}.upload 2>&1 || true

--- a/snap/hooks/connect-plug-config-logsync
+++ b/snap/hooks/connect-plug-config-logsync
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+snapctl restart ${SNAP_NAME}.upload 2>&1 || true

--- a/snap/hooks/connect-plug-log-observe
+++ b/snap/hooks/connect-plug-log-observe
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+snapctl restart ${SNAP_NAME}.upload 2>&1 || true

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,28 +9,22 @@ description: |
 grade: stable
 confinement: strict
 
-plugs:
-  config-logsync:
-    interface: system-files
-    read:
-      - /etc/systemd
-    write:
-      - /etc/systemd/journal-upload.conf
-
-hooks:
-  configure:
-    plugs:
-      - config-logsync
+layout:
+  /etc/systemd/journal-upload.conf:
+    bind-file: $SNAP_DATA/journal-upload.conf
 
 apps:
   upload:
     command: lib/systemd/systemd-journal-upload --save-state=$SNAP_DATA/state
     plugs:
+      - daemon-notify
       - network-bind
+      - network-control
       - network
-      - config-logsync
       - log-observe
+      - time-control # this quietens log spam at access of /proc/1/environ
     daemon: simple
+    watchdog-timeout: 3m
 
 parts:
   upload:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,9 +9,18 @@ description: |
 grade: stable
 confinement: strict
 
-layout:
-  /etc/systemd/journal-upload.conf:
-    bind-file: $SNAP_DATA/journal-upload.conf
+plugs:
+  config-logsync:
+    interface: system-files
+    read:
+      - /etc/systemd
+    write:
+      - /etc/systemd/journal-upload.conf
+
+hooks:
+  configure:
+    plugs:
+      - config-logsync
 
 apps:
   upload:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,11 +26,14 @@ apps:
   upload:
     command: lib/systemd/systemd-journal-upload --save-state=$SNAP_DATA/state
     plugs:
+      - daemon-notify
       - network-bind
+      - network-control
       - network
-      - config-logsync
       - log-observe
+      - time-control # this quietens log spam at access of /proc/1/environ
     daemon: simple
+    watchdog-timeout: 3m
 
 parts:
   upload:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,11 @@ plugs:
     write:
       - /etc/systemd/journal-upload.conf
 
+hooks:
+  configure:
+    plugs:
+      - config-logsync
+
 apps:
   upload:
     command: lib/systemd/systemd-journal-upload --save-state=/var/snap/logsync/current/state

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ hooks:
 
 apps:
   upload:
-    command: lib/systemd/systemd-journal-upload --save-state=/var/snap/logsync/current/state
+    command: lib/systemd/systemd-journal-upload --save-state=$SNAP_DATA/state
     plugs:
       - network-bind
       - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,8 +12,6 @@ confinement: strict
 plugs:
   config-logsync:
     interface: system-files
-    read:
-      - /etc/systemd
     write:
       - /etc/systemd/journal-upload.conf
 
@@ -26,6 +24,7 @@ apps:
   upload:
     command: lib/systemd/systemd-journal-upload --save-state=$SNAP_DATA/state
     plugs:
+      - config-logsync
       - daemon-notify
       - network-bind
       - network-control


### PR DESCRIPTION
- while the app has write access to /etc/systemd/journal-upload.conf, the configure hook does not, this PR adds a hook for it ...

- when starting the daemon, systemd-journal-upload tries a mkdir for the defined state directory but finds the "/current" link and fails. using $SNAP_DATA in the command option fixes this 

- after connecting interfaces, the service should be attenpted to be auto-started so the user does not need to manually do this ...

EDIT: actually strike that, a layout serves better than the system-files interface, the last commit completely swiches to layout so that the branch should also not go into manual review anymore. it adds a few additional interfaces to quieten systemd-journal-upload noise.