### PR TITLE
drop priv interface, properly switch to layout

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -32,21 +32,23 @@ fi
 
 # Create the config file (overwriting the existing one)
 echo "Setting up the configuration file"
-echo "[Upload]" > /etc/systemd/journal-upload.conf
-echo "URL=$url" >> /etc/systemd/journal-upload.conf
+echo "[Upload]" > $SNAP_DATA/systemd/journal-upload.conf
+# remove executable bit to quieten log spam on startup
+chmod -x $SNAP_DATA/systemd/journal-upload.conf
+echo "URL=$url" >> $SNAP_DATA/systemd/journal-upload.conf
 
 # Add the TLS certificate options
 if [ -n "$cert" ]; then
     filename=$(base64ToFile "$cert" "/var/snap/${SNAP_NAME}/current/upload.cert")
-    echo "ServerCertificateFile=$filename" >> /etc/systemd/journal-upload.conf
+    echo "ServerCertificateFile=$filename" >> $SNAP_DATA/systemd/journal-upload.conf
 fi
 if [ -n "$key" ]; then
     filename=$(base64ToFile "$key" "/var/snap/${SNAP_NAME}/current/upload.key")
-    echo "ServerKeyFile=$filename" >> /etc/systemd/journal-upload.conf
+    echo "ServerKeyFile=$filename" >> $SNAP_DATA/systemd/journal-upload.conf
 fi
 if [ -n "$ca" ]; then
     filename=$(base64ToFile "$ca" "/var/snap/${SNAP_NAME}/current/upload.ca")
-    echo "TrustedCertificateFile=$filename" >> /etc/systemd/journal-upload.conf
+    echo "TrustedCertificateFile=$filename" >> $SNAP_DATA/systemd/journal-upload.conf
 fi
 
 # Restart the service

--- a/snap/hooks/connect-plug-config-logsync
+++ b/snap/hooks/connect-plug-config-logsync
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-snapctl restart ${SNAP_NAME}.upload 2>&1 || true

--- a/snap/hooks/connect-plug-log-observe
+++ b/snap/hooks/connect-plug-log-observe
@@ -1,3 +1,8 @@
 #! /bin/sh
 
-snapctl restart ${SNAP_NAME}.upload 2>&1 || true
+url="$(snapctl get url)"
+
+# only restart if we are configured already
+if [ -n "$url" ]; then
+  snapctl restart ${SNAP_NAME}.upload 2>&1 || true
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,25 +6,26 @@ description: |
   Simple example snap to show how to send journal messages from a device
   to a remote journal server.
 
+  To run the snap you need to connect a few interfaces and set a receiver url
+  like below
+
+  sudo snap connect logsync-james:daemon-notify
+  sudo snap connect logsync-james:time-control
+  sudo snap connect logsync-james:network-control
+  sudo snap connect logsync-james:log-observe
+  sudo snap set logsync-james url="http://<ip of the machine running logsync-receiver>"
+
 grade: stable
 confinement: strict
 
-plugs:
-  config-logsync:
-    interface: system-files
-    write:
-      - /etc/systemd/journal-upload.conf
-
-hooks:
-  configure:
-    plugs:
-      - config-logsync
+layout:
+  /etc/systemd:
+    bind: $SNAP_DATA/systemd
 
 apps:
   upload:
     command: lib/systemd/systemd-journal-upload --save-state=$SNAP_DATA/state
     plugs:
-      - config-logsync
       - daemon-notify
       - network-bind
       - network-control


### PR DESCRIPTION
- layouts only work for /etc/systemd when bind mounting the whole dir instead of a non-exiting file
- adapt the code for the above, also make the config hook write to the file in $SNAP_DATA, not directly 
- drop connect hook for dropped plug
- only restart via log-observe connection hook when configured already
- add instructions to package description